### PR TITLE
Fix generate recipes not reading from actual inventory

### DIFF
--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -1,7 +1,6 @@
 package app;
 
 import java.awt.CardLayout;
-import java.util.ArrayList;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -67,7 +66,6 @@ import adapters.user_recipe.view_recipes.view_detailed_recipe.ViewUserRecipeDeta
 import databases.dietary_restriction.DietResDataAccessObject;
 import databases.dietary_restriction.MealDbIngredientGateway;
 import databases.favorites.FavoriteDataAccessObject;
-import databases.generate_recipe.InventoryReaderFromInventory;
 import databases.generate_recipe.MealDbRandomRecipeGateway;
 import databases.generate_recipe.MealDbRecipeByIngredientsGateway;
 import databases.generate_recipe.MealDbRecipeDetailsGateway;
@@ -75,7 +73,6 @@ import databases.generate_recipe.MealDbRecipeGateway;
 import databases.inventory.InventoryDataAccessObject;
 import databases.inventory.MealDbIngredientDataAccess;
 import databases.user_recipe.FileDataAccessObject;
-import entity.Inventory;
 import logic.dietary_restriction.DietaryRestrictionChecker;
 import logic.dietary_restriction.DietaryRestrictionCheckerInterface;
 import logic.dietary_restriction.add_restrictions.AddDietResInteractor;
@@ -177,7 +174,7 @@ public class AppBuilder {
      */
 
     private InventoryView inventoryView;
-    private final Inventory inventory = new Inventory(new ArrayList<>());
+    private final InventoryDataAccessObject inventoryDao = new InventoryDataAccessObject();
     private final SearchIngredientsViewModel searchIngredientsViewModel = new SearchIngredientsViewModel();
     private final AddIngredientViewModel addIngredientViewModel = new AddIngredientViewModel();
     private final RemoveIngredientViewModel removeIngredientViewModel = new RemoveIngredientViewModel();
@@ -505,7 +502,6 @@ public class AppBuilder {
      */
     public AppBuilder addInventoryView() {
         final MealDbIngredientDataAccess dataAccess = new MealDbIngredientDataAccess();
-        final InventoryDataAccessObject inventoryDataObject = new InventoryDataAccessObject();
 
         final SearchIngredientsPresenter searchPresenter =
                 new SearchIngredientsPresenter(searchIngredientsViewModel);
@@ -516,17 +512,17 @@ public class AppBuilder {
 
         final AddIngredientPresenter addPresenter = new AddIngredientPresenter(addIngredientViewModel);
         final AddIngredientInteractor addInteractor =
-                new AddIngredientInteractor(addPresenter, inventoryDataObject);
+                new AddIngredientInteractor(addPresenter, inventoryDao);
         final AddIngredientController addController = new AddIngredientController(addInteractor);
 
         final RemoveIngredientPresenter removePresenter =
                 new RemoveIngredientPresenter(removeIngredientViewModel);
         final RemoveIngredientInteractor removeInteractor =
-                new RemoveIngredientInteractor(removePresenter, inventoryDataObject);
+                new RemoveIngredientInteractor(removePresenter, inventoryDao);
         final RemoveIngredientController removeController = new RemoveIngredientController(removeInteractor);
 
         inventoryView = new InventoryView(searchController, addController, removeController,
-                searchIngredientsViewModel, inventoryDataObject);
+                searchIngredientsViewModel, inventoryDao);
 
         mainView.addInventoryTab(inventoryView);
 
@@ -763,15 +759,12 @@ public class AppBuilder {
         final MealDbRecipeGateway recipeGateway = new MealDbRecipeGateway();
         recipeGateway.preloadAllRecipes();
 
-        final InventoryReaderFromInventory inventoryReader =
-                new InventoryReaderFromInventory(this.inventory);
-
         final GenerateWithInventoryViewModel generateWithInventoryViewModel =
                 new GenerateWithInventoryViewModel();
 
         final GenerateByInventoryPanel panel = getGenerateByInventoryPanel(
                 generateWithInventoryViewModel,
-                inventoryReader,
+                inventoryDao,
                 recipeGateway
         );
 
@@ -815,7 +808,6 @@ public class AppBuilder {
      * @return this AppBuilder instance for method chaining
      */
     public AppBuilder addMissingIngredientsUseCase() {
-        final InventoryDataAccessObject inventoryDao = new InventoryDataAccessObject();
         final MissingIngredientsPresenter presenter = new MissingIngredientsPresenter(recipeDetailsWindow);
         final MissingIngredientsInteractor interactor = new MissingIngredientsInteractor(inventoryDao, presenter);
         missingIngredientsController = new MissingIngredientsController(interactor);

--- a/src/main/java/databases/inventory/InventoryDataAccessObject.java
+++ b/src/main/java/databases/inventory/InventoryDataAccessObject.java
@@ -5,13 +5,16 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import entity.Ingredient;
+import logic.generate_recipe.generate_with_inventory.InventoryReader;
 import logic.inventory.add_ingredient.InventoryDataAccessInterface;
 import logic.inventory.missing_ingredients.InventoryReaderInterface;
 import logic.inventory.remove_ingredient.RemoveIngredientDataAccessInterface;
@@ -21,7 +24,7 @@ import logic.inventory.remove_ingredient.RemoveIngredientDataAccessInterface;
  * Stores inventory in a JSON file and automatically saves on add/remove operations.
  */
 public class InventoryDataAccessObject implements InventoryDataAccessInterface,
-        RemoveIngredientDataAccessInterface, InventoryReaderInterface {
+        RemoveIngredientDataAccessInterface, InventoryReaderInterface, InventoryReader {
 
     private static final int JSON_INDENT = 4;
 
@@ -83,6 +86,20 @@ public class InventoryDataAccessObject implements InventoryDataAccessInterface,
      */
     public List<Ingredient> getAllIngredients() {
         return new ArrayList<>(ingredients);
+    }
+
+    @Override
+    public Set<String> getAll() {
+        final Set<String> names = new HashSet<>();
+        for (Ingredient ingredient : ingredients) {
+            if (ingredient != null && ingredient.getName() != null) {
+                final String name = ingredient.getName().trim().toLowerCase();
+                if (!name.isEmpty()) {
+                    names.add(name);
+                }
+            }
+        }
+        return names;
     }
 
     /**

--- a/src/main/java/databases/inventory/InventoryDataAccessObject.java
+++ b/src/main/java/databases/inventory/InventoryDataAccessObject.java
@@ -61,9 +61,9 @@ public class InventoryDataAccessObject implements InventoryDataAccessInterface,
 
     @Override
     public boolean removeIngredient(Ingredient ingredient) {
-        final boolean removed = ingredients.removeIf(existing ->
-                existing.getName().equalsIgnoreCase(ingredient.getName())
-        );
+        final boolean removed = ingredients.removeIf(existing -> {
+            return existing.getName().equalsIgnoreCase(ingredient.getName());
+        });
 
         if (removed) {
             saveInventoryToFile();
@@ -108,31 +108,24 @@ public class InventoryDataAccessObject implements InventoryDataAccessInterface,
      */
     private void loadInventory() {
         final File file = new File(filePath);
+        ingredients = new ArrayList<>();
 
-        if (!file.exists()) {
-            ingredients = new ArrayList<>();
-            return;
-        }
+        if (file.exists()) {
+            try {
+                final String jsonContent = Files.readString(file.toPath());
 
-        try {
-            final String jsonContent = Files.readString(file.toPath());
+                if (!jsonContent.isBlank()) {
+                    final JSONArray jsonArray = new JSONArray(jsonContent);
 
-            if (jsonContent.isBlank()) {
+                    for (int i = 0; i < jsonArray.length(); i++) {
+                        final JSONObject ingredientJson = jsonArray.getJSONObject(i);
+                        ingredients.add(jsonToIngredient(ingredientJson));
+                    }
+                }
+            }
+            catch (IOException | JSONException ex) {
                 ingredients = new ArrayList<>();
-                return;
             }
-
-            final JSONArray jsonArray = new JSONArray(jsonContent);
-            ingredients = new ArrayList<>();
-
-            for (int i = 0; i < jsonArray.length(); i++) {
-                final JSONObject ingredientJson = jsonArray.getJSONObject(i);
-                ingredients.add(jsonToIngredient(ingredientJson));
-            }
-
-        }
-        catch (IOException | JSONException ex) {
-            ingredients = new ArrayList<>();
         }
     }
 


### PR DESCRIPTION
The generate recipes feature was always showing 'please add more ingredients' because it was reading from an empty in-memory Inventory object instead of the actual inventory.json file.

Changed InventoryDataAccessObject to also implement InventoryReader interface and made AppBuilder use a single shared instance so all features (add/remove ingredients, generate recipes, missing ingredients) now read from the same data source.